### PR TITLE
Don't fail the build if the regex is not found

### DIFF
--- a/main.js
+++ b/main.js
@@ -13,8 +13,10 @@ async function run() {
     let content = fs.readFileSync(filePath)
     let regex = new RegExp(core.getInput('extraction_regex'))
     let matches = String(content).match(regex)
-    if (!matches)
-      return core.setFailed(`no match was found for the regex '${regex.toString()}'.`)
+    if (!matches) {
+      core.warning(`no match was found for the regex '${regex.toString()}'.`)
+      return
+    }
 
     let version = matches[matches.length - 1]
     let format = core.getInput('tag_format', { required: false }).trim()


### PR DESCRIPTION
This makes it possible to point the action to a version history file that does not contain any release versions yet.

Fixes #1.